### PR TITLE
Fix regexp on ufw status - refs #26

### DIFF
--- a/scripts/img_check.sh
+++ b/scripts/img_check.sh
@@ -333,7 +333,7 @@ function checkFirewall {
     
     if [[ $OS == "Ubuntu" ]]; then
       fw="ufw"
-      ufwa=$(ufw status | sed -e "s/^Status:\ //")
+      ufwa=$(ufw status | grep "Status:" | sed "s/^Status: \(.*\)/\1/")
       if [[ $ufwa == "active" ]]; then
         FW_VER="\e[32m[PASS]\e[0m Firewall service (${fw}) is active\n"
         ((PASS++))


### PR DESCRIPTION
The current expression doesn't capture an "active" status, only "inactive" (because an ufw status of inactive only has one line of result). This new expression first reduces the result to the Status line, then filters down active/inactive.